### PR TITLE
docs: fix package name from "errors" to "errgo"

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Is returns a function that returns whether the an error is equal to the given
 error. It is intended to be used as a "pass" argument to Mask and friends; for
 example:
 
-    return errors.Mask(err, errors.Is(http.ErrNoCookie))
+    return errgo.Mask(err, errgo.Is(http.ErrNoCookie))
 
 would return an error with an http.ErrNoCookie cause only if that was err's
 diagnosis; otherwise the diagnosis would be itself.
@@ -75,7 +75,7 @@ from the os.Open call when (and only when) the file does not exist.
 
     f, err := os.Open("non-existent-file")
     if err != nil {
-    	return errors.Mask(err, os.IsNotExist)
+        return errgo.Mask(err, os.IsNotExist)
     }
 
 In order to add context to returned errors, it is conventional to call Mask when

--- a/errors.go
+++ b/errors.go
@@ -209,7 +209,7 @@ func match(err error, pass ...func(error) bool) bool {
 // It is intended to be used as a "pass" argument
 // to Mask and friends; for example:
 //
-// 	return errors.Mask(err, errors.Is(http.ErrNoCookie))
+// 	return errgo.Mask(err, errgo.Is(http.ErrNoCookie))
 //
 // would return an error with an http.ErrNoCookie cause
 // only if that was err's diagnosis; otherwise the diagnosis
@@ -270,7 +270,7 @@ func NoteMask(underlying error, msg string, pass ...func(error) bool) error {
 //
 //	f, err := os.Open("non-existent-file")
 //	if err != nil {
-//		return errors.Mask(err, os.IsNotExist)
+//		return errgo.Mask(err, os.IsNotExist)
 //	}
 //
 // In order to add context to returned errors, it


### PR DESCRIPTION
Examples in docs erroneously referred to package as "errors"; change to "errgo". (On a side note, using [the examples feature of testing / godoc](http://golang.org/pkg/testing/#hdr-Examples) can help prevent examples from going out-of-sync with code.)
