### PR TITLE
respect underlying error in WithCausef

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -333,11 +333,11 @@ func MaskFunc(allow ...func(error) bool) func(error, ...func(error) bool) error 
 // WithCausef returns a new Error that wraps the given
 // (possibly nil) underlying error and associates it with
 // the given cause. The given formatted message context
-// will also be added. If f is empty and has no arguments,
+// will also be added. If underlying is nil and f is empty and has no arguments,
 // the message will be the same as the cause.
 func WithCausef(underlying, cause error, f string, a ...interface{}) error {
 	var msg string
-	if f == "" && len(a) == 0 && cause != nil {
+	if underlying == nil && f == "" && len(a) == 0 && cause != nil {
 		msg = cause.Error()
 	} else {
 		msg = fmt.Sprintf(f, a...)

--- a/errors_test.go
+++ b/errors_test.go
@@ -181,6 +181,14 @@ func (*errorsSuite) TestWithCausefNoMessage(c *gc.C) {
 	c.Assert(errgo.Cause(err), gc.Equals, cause)
 }
 
+func (*errorsSuite) TestWithCausefWithUnderlyingButNoMessage(c *gc.C) {
+	err := errgo.New("something")
+	cause := errgo.New("cause")
+	err = errgo.WithCausef(err, cause, "")
+	c.Assert(err, gc.ErrorMatches, "something")
+	c.Assert(errgo.Cause(err), gc.Equals, cause)
+}
+
 func (*errorsSuite) TestDetails(c *gc.C) {
 	c.Assert(errgo.Details(nil), gc.Equals, "[]")
 


### PR DESCRIPTION
If we pass an underlying error to WithCausef, we want the
error message to reflect that, even if the added message
is empty. Without this, it's not easy to change the cause
of an error without changing its message.

Also fix doc comments to use "errgo" not "errors".