### PR TITLE
rename Locationer to Locator

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -139,7 +139,7 @@ func SetLocation(err error, callDepth int) {
 //			{otherfile:55: cause of error one}
 //		]
 //
-// The details are found by type-asserting the error to the Locationer,
+// The details are found by type-asserting the error to the Locator,
 // Causer and Wrapper interfaces. Details of the underlying stack are
 // found by recursively calling Underlying when the underlying error
 // implements Wrapper.
@@ -151,7 +151,7 @@ func Details(err error) string {
 	s = append(s, '[')
 	for {
 		s = append(s, "\n\t{"...)
-		if err, ok := err.(Locationer); ok {
+		if err, ok := err.(Locator); ok {
 			file, line := err.Location()
 			if file != "" {
 				s = append(s, file...)

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -237,7 +237,7 @@ type customError struct {
 }
 
 func (e customError) Location() (string, int) {
-	if err, ok := e.error.(errors.Locationer); ok {
+	if err, ok := e.error.(errors.Locator); ok {
 		return err.Location()
 	}
 	return "", 0

--- a/errors/interface.go
+++ b/errors/interface.go
@@ -21,9 +21,13 @@ type Wrapper interface {
 	Underlying() error
 }
 
-// Locationer can be implemented by any error type that wants to expose
+// Deprecated: Locationer is the old name for Locator,
+// kept for backward compatibility only.
+type Locationer = Locator
+
+// Locator can be implemented by any error type that wants to expose
 // the source location of an error.
-type Locationer interface {
+type Locator interface {
 	// Location returns the name of the file and the line number
 	// associated with an error.
 	Location() (file string, line int)

--- a/errors/struct.go
+++ b/errors/struct.go
@@ -87,7 +87,7 @@ func (e *errorInfo) setLocation(callDepth int) {
 	}
 }
 
-// Location implements Locationer.
+// Location implements Locator.
 func (e *errorInfo) Location() (file string, line int) {
 	frames := runtime.CallersFrames(e.callerPC[:])
 	frame, ok := frames.Next()

--- a/fmt/errors/alias.go
+++ b/fmt/errors/alias.go
@@ -5,10 +5,14 @@ import (
 )
 
 type (
-	Causer     = errors.Causer
-	Wrapper    = errors.Wrapper
-	Locationer = errors.Locationer
+	Causer  = errors.Causer
+	Wrapper = errors.Wrapper
+	Locator = errors.Locator
 )
+
+// Deprecated: Locationer is the old name for Locator,
+// kept for backward compatibility only.
+type Locationer = errors.Locationer
 
 // New returns a new error with the given error message and no cause. It
 // is a drop-in replacement for errors.New from the standard library.
@@ -81,7 +85,7 @@ func SetLocation(err error, callDepth int) {
 // 	[{filename:99: error one} {otherfile:55: cause of error one}]
 //
 // The details are found by type-asserting the error to
-// the Locationer, Causer and Wrapper interfaces.
+// the Locator, Causer and Wrapper interfaces.
 // Details of the underlying stack are found by
 // recursively calling Underlying when the
 // underlying error implements Wrapper.

--- a/fmt/errors/errors_test.go
+++ b/fmt/errors/errors_test.go
@@ -267,7 +267,7 @@ type customError struct {
 }
 
 func (e customError) Location() (string, int) {
-	if err, ok := e.error.(errors.Locationer); ok {
+	if err, ok := e.error.(errors.Locator); ok {
 		return err.Location()
 	}
 	return "", 0


### PR DESCRIPTION
Locationer is not a good name.
Keep it around for backward compatibility, but deprecated.