### PR TITLE
Add Unwrap

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -58,6 +58,12 @@ func (e *Err) Cause() error {
 	return e.Cause_
 }
 
+// Unwrap makes Err compatible with the go 1.13 standard library's
+// errors.Unwrap function, it has identical behaviour to Cause.
+func (e *Err) Unwrap() error {
+	return e.Cause()
+}
+
 // Message returns the top level error message.
 func (e *Err) Message() string {
 	return e.Message_

--- a/errors_go1.13_test.go
+++ b/errors_go1.13_test.go
@@ -1,0 +1,23 @@
+// +build go1.13
+
+package errgo_test
+
+import (
+	"errors"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"gopkg.in/errgo.v1"
+)
+
+func TestUnwrap(t *testing.T) {
+	c := qt.New(t)
+
+	causeErr := errgo.New("cause error")
+	underlyingErr := errgo.New("underlying error")       //err TestCause#1
+	err := errgo.WithCausef(underlyingErr, causeErr, "") //err TestCause#2
+
+	c.Assert(errors.Unwrap(err), qt.Equals, causeErr)
+	c.Assert(errors.Unwrap(causeErr), qt.Equals, nil)
+}


### PR DESCRIPTION
Make Err compatible with the standard library's errors.Unwrap function
by adding an Unwrap method that is identical to the current Cause method.